### PR TITLE
flexibility to allow apps to use optimizations

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -4,7 +4,8 @@ module MemPool
 
 import Base: serialize, deserialize
 export DRef, FileRef, poolset, poolget, pooldelete, destroyonevict,
-       movetodisk, copytodisk, savetodisk, mmwrite, mmread
+       movetodisk, copytodisk, savetodisk, mmwrite, mmread, cleanup,
+       deletefromdisk
 
 ## Wrapping-unwrapping of payloads:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,3 +136,9 @@ end
     r2 = remotecall_fetch(()->MemPool.poolget(fref), 2)
     @test MemPool.who_has_read[f][1].owner == 2
 end
+
+@testset "cleanup" begin
+    @everywhere MemPool.cleanup()
+    d = MemPool.default_dir(myid())
+    @test !isdir(d)
+end


### PR DESCRIPTION
Some changes and apis to allow optimizing resource usage:
- allow switching off central tracking of `who-has-read-what`; to avoid remote calls when this feature is not needed
- cleanup `FileRef`; to clean up intermediate results
- clean up all stored states; allows a process to clean all intermediate stored results in a session