### PR TITLE
keep machine IP with FileRef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.mempool

--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -35,8 +35,13 @@ end
 # This allows communicating only the file name across processors,
 # the receiver process will simply read from file while unwrapping
 struct FileRef
+    host::IPAddr
     file::String
     size::UInt
+
+    function FileRef(file, size)
+        new(host, file, size)
+    end
 end
 
 unwrap_payload(f::FileRef) = unwrap_payload(open(deserialize, f.file))
@@ -74,6 +79,9 @@ function approx_size(xs::Array{String})
     sum(map(sizeof, xs)) + 4 * length(xs)
 end
 
-__init__() = global session = "sess-" * randstring(5)
+function __init__()
+    global session = "sess-" * randstring(5)
+    global host = getipaddr()
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,7 @@ end
     ref = poolset([1,2], 2)
     fref = movetodisk(ref)
     @test isa(fref, MemPool.FileRef)
+    @test fref.host == getipaddr()
     @test poolget(fref) == poolget(ref)
     f = tempname()
     fref2 = savetodisk(ref, f)


### PR DESCRIPTION
Adds an IP address field to identify the node/machine where file is located.
Allows linking only a single IP.

minimal changes to fix #3