### PR TITLE
 always mmap files in "r+" mode

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -44,7 +44,7 @@ struct FileRef
     end
 end
 
-unwrap_payload(f::FileRef) = unwrap_payload(open(deserialize, f.file))
+unwrap_payload(f::FileRef) = unwrap_payload(open(deserialize, f.file, "r+"))
 
 include("io.jl")
 include("datastore.jl")

--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -110,7 +110,7 @@ function _getlocal(id, remote)
             # TODO: get memory mapped size and not count it as
             # much as local process size
             lru_free(state.size)
-            data = unwrap_payload(open(deserialize, get(state.file)))
+            data = unwrap_payload(open(deserialize, get(state.file), "r+"))
             state.data = Nullable{Any}(data)
             lru_touch(id, state.size) # load back to memory
             return data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
+include("testenv.jl")
+
 if nprocs() == 1
-    addprocs(1)
+    addprocs_with_testenv(1)
 end
 
 using MemPool

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -1,0 +1,30 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# This includes a few helper variables and functions that provide information about the
+# test environment (command line flags, current module, etc).
+# This file can be included multiple times in the same module if necessary,
+# which can happen with unisolated test runs.
+
+if !isdefined(:testenv_defined)
+    const testenv_defined = true
+    if haskey(ENV, "JULIA_TEST_EXEFLAGS")
+        const test_exeflags = `$(Base.shell_split(ENV["JULIA_TEST_EXEFLAGS"]))`
+    else
+        inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
+        cov_flag = ``
+        if Base.JLOptions().code_coverage == 1
+            cov_flag = `--code-coverage=user`
+        elseif Base.JLOptions().code_coverage == 2
+            cov_flag = `--code-coverage=all`
+        end
+        const test_exeflags = `$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`
+    end
+
+    if haskey(ENV, "JULIA_TEST_EXENAME")
+        const test_exename = `$(Base.shell_split(ENV["JULIA_TEST_EXENAME"]))`
+    else
+        const test_exename = `$(Base.julia_exename())`
+    end
+
+    addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)
+end


### PR DESCRIPTION
- always mmap files in "r+" mode, because the caller may potentially want to update the data
- extend coverage to workers