### PR TITLE
optoin to return random or specific worker for fileref fetch

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,10 @@ end
     pooldelete(ref)
     @test fetch(@spawnat 2 isempty(MemPool.lru_order))
     @test fetch(@spawnat 2 isempty(MemPool.datastore))
+    @test MemPool.get_worker_at(getipaddr()) == 1
+    @test MemPool.get_worker_at("127.0.0.1") in [1,2]
+    @test MemPool.is_my_ip(getipaddr())
+    @test !MemPool.is_my_ip("127.0.0.1")
 end
 
 inmem(ref, pid=myid()) = remotecall_fetch(id -> MemPool.isinmemory(MemPool.datastore[id]), ref.owner, ref.id)


### PR DESCRIPTION
By default MemPool will use a random worker on a node to fetch a `FileRef`. Optionally `MemPool.enable_random_fref_serve[]` can be set to `false` to have it use a specific worker (the one with lowest worker id) for this role. Useful in cases where it desirable to have a specific process designated for IO tasks.

Also added tests for new methods.