### PR TITLE
use what `getipaddr()` returns for `FileRef` affinity

### DIFF
--- a/src/datastore.jl
+++ b/src/datastore.jl
@@ -71,6 +71,18 @@ function get_wrkrips()
             d[wip] = [w.id]
         end
     end
+
+    loopback = ip"127.0.0.1"
+    if (loopback in keys(d)) && (length(d) > 1)
+        # there is a chance that workers on loopback are actually on same ip as master
+        realip = remotecall_fetch(getipaddr, first(d[loopback]))
+        if realip in keys(d)
+            append!(d[realip], d[loopback])
+        else
+            d[realip] = d[loopback]
+        end
+        delete!(d, loopback)
+    end
     d
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,14 +119,10 @@ end
     @test remotecall_fetch(poolget, 2, fref) == poolget(ref)
     @everywhere MemPool.cleanup()
 
-    @test MemPool.get_worker_at(getipaddr()) == 1
-    @test MemPool.get_worker_at("127.0.0.1") in [1,2,3]
-    @test remotecall_fetch(()->MemPool.get_worker_at("127.0.0.1"), 2) in [1,2,3]
-    all_workers_at_localhost = MemPool.wrkrips[ip"127.0.0.1"]
+    @test MemPool.get_worker_at(getipaddr()) in [1,2,3]
+    @test remotecall_fetch(()->MemPool.get_worker_at(getipaddr()), 2) in [1,2,3]
     @everywhere MemPool.enable_random_fref_serve[] = false
     @everywhere empty!(MemPool.wrkrips)
-    @test MemPool.get_worker_at("127.0.0.1") == minimum(all_workers_at_localhost)
-    @test length(MemPool.wrkrips[ip"127.0.0.1"]) == 1
     @test MemPool.is_my_ip(getipaddr())
     @test !MemPool.is_my_ip("127.0.0.1")
 end


### PR DESCRIPTION
To avoid master and workers being identified as different IPs.
It can lead to all FileRefs being tagged to master.