### PR TITLE
check for isbitsunion in fixedlength

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -143,7 +143,7 @@ end
 ## E.g. this is very good for `StaticArrays.MVector`s
 
 function fixedlength(t::Type, cycles=IdDict())
-    if isbitstype(t)
+    if isbitstype(t) || Base.isbitsunion(t)
         return sizeof(t)
     elseif isa(t, UnionAll) || isabstracttype(t)
         return -1


### PR DESCRIPTION
This fixes a `ArgumentError: type does not have a definite number of fields` issue when column types are unions of bitstypes.