### PR TITLE
Fix some cases with Union{T,Missing}

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -143,7 +143,7 @@ end
 ## E.g. this is very good for `StaticArrays.MVector`s
 
 function fixedlength(t::Type, cycles=IdDict())
-    if isbitstype(t) || Base.isbitstype(t)
+    if isbitstype(t) || Base.isbitsunion(t)
         return sizeof(t)
     elseif isa(t, UnionAll) || isabstracttype(t) || Base.isbitsunion(t)
         return -1

--- a/src/io.jl
+++ b/src/io.jl
@@ -143,7 +143,7 @@ end
 ## E.g. this is very good for `StaticArrays.MVector`s
 
 function fixedlength(t::Type, cycles=IdDict())
-    if isbitstype(t)
+    if isbitstype(t) || Base.isbitstype(t)
         return sizeof(t)
     elseif isa(t, UnionAll) || isabstracttype(t) || Base.isbitsunion(t)
         return -1


### PR DESCRIPTION
return >0 for `fixedlength(::Union{T,Missing})`