### PR TITLE
Fix init when without network interface

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -100,7 +100,11 @@ end
 
 function __init__()
     global session = "sess-" * randstring(5)
-    global host = getipaddr()
+    try
+        global host = getipaddr()
+    catch err
+        global host = Sockets.localhost
+    end
 end
 
 end # module


### PR DESCRIPTION
When a network interface is not available, `Sockets.getipaddr()` will throw an error. This will cause MemPool to fail to load when the user does not have internet access (or another kind of network interface assigning an IP address). Here we catch that error and instead just fall back to `Sockets.localhost` to allow MemPool to load in these cases.