### PR TITLE
Fix typo in deserialize

### DIFF
--- a/src/MemPool.jl
+++ b/src/MemPool.jl
@@ -25,7 +25,7 @@ function serialize(io::AbstractSerializer, w::MMWrap)
     mmwrite(io, w.x)
 end
 
-function deserialize(io::AbstractSerializer, ::Type{MMWrap})
+function deserialize(io::AbstractSerializer, T::Type{MMWrap})
     MMWrap(mmread(T, io)) # gotta keep that wrapper on
 end
 


### PR DESCRIPTION
Fixes a typo that causes some [malfunction](https://github.com/JuliaComputing/MemPool.jl/issues/27).